### PR TITLE
Add team details page after clicking on teams from dashboard

### DIFF
--- a/task_manager/urls.py
+++ b/task_manager/urls.py
@@ -28,4 +28,5 @@ urlpatterns = [
     path('profile/', views.ProfileUpdateView.as_view(), name='profile'),
     path('sign_up/', views.SignUpView.as_view(), name='sign_up'),
     path('create_team/', views.create_team, name='create_team'),
+    path('team/<int:team_id>', views.show_team, name='show_team'),
 ]

--- a/tasks/admin.py
+++ b/tasks/admin.py
@@ -1,3 +1,28 @@
 from django.contrib import admin
+from .models import User, Team
 
 # Register your models here.
+@admin.register(User) # our model we created
+class UserAdmin(admin.ModelAdmin):
+    """Configuration of the admin interface for users."""
+    
+    # list of attributes we want to see in table of user models (in the table view of users)
+    list_display = [
+        'username', 'first_name', 'last_name', 'email', 'id', 'is_active',
+    ]
+
+@admin.register(Team) # our model we created
+class TeamAdmin(admin.ModelAdmin):
+    """Configuration of the admin interface for teams."""
+    
+    # list of attributes we want to see in table of team models (in the table view of teams)
+    list_display = [
+        'title', 'description','id', 'display_members',
+    ]
+
+    def display_members(self, obj):
+        return ", ".join([member.username for member in obj.members.all()])
+
+    display_members.short_description = 'Members'
+
+

--- a/tasks/templates/dashboard.html
+++ b/tasks/templates/dashboard.html
@@ -14,11 +14,22 @@
       </div>
       <h3>Your Teams</h3>
         {% if user_teams %}
-          <ul>
-            {% for team in user_teams %}
-              <li>{{ team.title }} - {{ team.description }}</li>
-            {% endfor %}
-          </ul>
+          <table class="table">
+                <thead>
+                  <tr>
+                    <th>Team Name</th>
+                    <th>Description</th>
+                  </tr>
+                </thead>
+                {% for team in user_teams %}
+                    <tbody>
+                        <tr>
+                            <td><a href="{% url 'show_team' team.id %}">{{ team.title }}</a></td>
+                            <td>{{ team.description }}</td>
+                        </tr>
+                    </tbody>
+                {% endfor %}
+          </table>
         {% else %}
           <p>You haven't created any teams yet.</p>
         {% endif %}

--- a/tasks/templates/partials/team_details.html
+++ b/tasks/templates/partials/team_details.html
@@ -1,0 +1,20 @@
+<div class="row content">
+    <div class="col-12">
+        <h2 class="text-primary">Team Name: {{ team.title }}</h2>
+    </div>
+</div>
+<div class="row content">
+    <div class="col-12">
+        <p class="lead">Description: {{ team.description }}</p>
+    </div>
+</div>
+<div class="row content">
+    <div class="col-12">
+        <p class="team-members">Members:
+            {% for member in team.members.all %}
+                {{ member.username }},
+            {% endfor %}
+        </p>
+    </div>
+</div>
+

--- a/tasks/templates/show_team.html
+++ b/tasks/templates/show_team.html
@@ -1,0 +1,10 @@
+{% extends 'base_content.html' %}
+{% block content %}
+<div class="container">
+    <div class="row content">
+        <div class="col-xs-12 col-lg-6 col-xl-4">
+            {% include 'partials/team_details.html' %}
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/tasks/tests/views/test_show_team_view.py
+++ b/tasks/tests/views/test_show_team_view.py
@@ -1,0 +1,83 @@
+""" Tests of the Show Team view """
+from django.test import TestCase
+from django.urls import reverse
+from tasks.models import Team, User
+from tasks.tests.helpers import reverse_with_next
+
+
+class ShowTeamViewTestCase(TestCase):
+    """ Tests of the Show Team view """
+
+    fixtures = [
+        'tasks/tests/fixtures/default_user.json',
+        'tasks/tests/fixtures/other_users.json'
+    ]
+
+    def setUp(self):
+        super(TestCase, self).setUp()
+        self.user = User.objects.get(username="@johndoe")
+
+        # teammate but not current logged in user
+        self.teammate_1 = User.objects.get(username="@janedoe")
+
+        # mock team created by user
+        self.team = Team.objects.create(
+            author=self.user,
+            title="TeamA",
+            description="This is my team",
+        )
+        self.team.members.add(self.user, self.teammate_1)
+
+        self.url = reverse('show_team', kwargs={'team_id': self.team.id})
+
+        '''
+        - TO BE IMPLEMENTED AFTER USER INVITE FEATURE IS DONE: -
+        # mock team created by team mate
+        self.team_other = Team.objects.create(
+            author=self.teammate_1,
+            title="TeamB",
+            description="This is my team",
+        )
+        self.team_other.members.add(self.user, self.teammate_1)
+        '''
+
+    def test_show_team_url(self):
+        expectedURL = '/team/' + str(self.team.id)
+        self.assertEqual(self.url, expectedURL)
+
+    def test_show_team_displays_team_name(self):
+        self.client.login(username=self.user.username, password="Password123")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'show_team.html')
+        self.assertContains(response, self.team.title)
+
+    def test_show_team_displays_description(self):
+        self.client.login(username=self.user.username, password="Password123")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'show_team.html')
+        self.assertContains(response, self.team.description)
+
+    def test_show_team_displays_all_members(self):
+        self.client.login(username=self.user.username, password="Password123")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'show_team.html')
+        membersInTeam = self.team.members.all() 
+        for member in membersInTeam:
+            self.assertContains(response, member)
+
+    def test_team_redirects_when_not_logged_in(self):
+        redirect_url = reverse_with_next("log_in", self.url)
+        response = self.client.get(self.url)
+        self.assertRedirects(response, redirect_url, status_code=302, target_status_code=200)
+
+    def test_get_show_teamwith_invalid_id(self):
+        self.client.login(username=self.user.username, password="Password123")
+        url = reverse('show_team', kwargs={'team_id': self.team.id+9999999})
+        response = self.client.get(url, follow=True)
+        response_url = reverse('dashboard')
+        self.assertRedirects(response, response_url, status_code=302, target_status_code=200)
+        self.assertTemplateUsed(response, 'dashboard.html')
+    

--- a/tasks/views.py
+++ b/tasks/views.py
@@ -10,9 +10,8 @@ from django.views.generic.edit import FormView, UpdateView
 from django.urls import reverse
 from tasks.forms import LogInForm, PasswordForm, UserForm, SignUpForm , TeamForm
 from tasks.helpers import login_prohibited
-
+from django.core.exceptions import ObjectDoesNotExist
 from django.http import HttpResponseForbidden
-
 from tasks.models import Team
 
 
@@ -35,6 +34,7 @@ def create_team(request):
                 titleCleaned = form.cleaned_data.get("title")
                 descriptionCleaned = form.cleaned_data.get('description')
                 team = Team.objects.create(author=current_user, title = titleCleaned, description=descriptionCleaned)
+                team.members.add(current_user) # adds only the team creator for now
                 return redirect('dashboard')
             else:
                 return render(request, 'create_team.html', {'form': form})
@@ -49,6 +49,16 @@ def home(request):
     """Display the application's start/home screen."""
 
     return render(request, 'home.html')
+
+@login_required
+def show_team(request, team_id):
+    """Show the team details: team name, description, members"""
+    try:
+        team = Team.objects.get(id=team_id)
+    except ObjectDoesNotExist:
+        return redirect('dashboard')
+    else:
+        return render(request, 'show_team.html', {'team': team})
 
 
 class LoginProhibitedMixin:


### PR DESCRIPTION
- Create show_team view with @login_required
- Created super admin
- Add test case for show_team view
- Add line to add author of team to team in create_team view function
- Display teams on dashboard in a table